### PR TITLE
ScalingInX changes

### DIFF
--- a/RotationInY/RotationInYTests.c
+++ b/RotationInY/RotationInYTests.c
@@ -32,7 +32,7 @@ int testGetPointReturnsNullWhenIndexIsNeagtive() {
 // Dirty Test
 // Tests When the value of the index exceeds the max length
 int testGetPointReturnsNullWhenIndexIsGreaterThanLength() {
-    return getPoint(inputShape->numOfPoints) == NULL;
+    return getPoint(inputShape->numOfVectors) == NULL;
 }
 
 // Clean Test
@@ -109,7 +109,7 @@ int testSetPointReturn0WhenIndexIsNegative() {
 int testSetPointReturn0WhenIndexIsGreaterThenLength() {
     // index and point
     struct point *newPoint = malloc(sizeof(struct point));
-    int index = inputShape->numOfPoints;
+    int index = inputShape->numOfVectors;
 
     // fill point
     for (int i = 0; i < 4; i++) {
@@ -363,7 +363,7 @@ int testYRotationWhenAngleIs0() {
 
     yRotation();
 
-    for (int i = 0; i < inputShape->numOfPoints; i++) {
+    for (int i = 0; i < inputShape->numOfVectors; i++) {
         for (int j = 0; j < 4; j++) {
             if (expected[i]->element[j] != inputShape->points[i]->element[j]) {
                 for (int i = 0; i < 5; i++) {
@@ -400,7 +400,7 @@ int testYRotationWhenAngleIsNegative() {
     yRotation();
 
     // seing if the results match
-    for (int i = 0; i < inputShape->numOfPoints; i++) {
+    for (int i = 0; i < inputShape->numOfVectors; i++) {
         for (int j = 0; j < 4; j++) {
             if (compareFloat(expected[i]->element[j], inputShape->points[i]->element[j], 0.000001)) {
                 for (int i = 0; i < 5; i++) {
@@ -437,7 +437,7 @@ int testYRotationWhenAngleIsPositiveGreaterThanTwoPi() {
     yRotation();
 
     // seeing if the results match
-    for (int i = 0; i < inputShape->numOfPoints; i++) {
+    for (int i = 0; i < inputShape->numOfVectors; i++) {
         for (int j = 0; j < 4; j++) {
             if (compareFloat(expected[i]->element[j], inputShape->points[i]->element[j], 0.000001)) {
                 for (int i = 0; i < 5; i++) {
@@ -476,7 +476,7 @@ int testYRotationHandlesNullMatrix() {
     yRotation();
 
     transformationMatrix = temp;
-    for (int i = 0; i < inputShape->numOfPoints; i++) {
+    for (int i = 0; i < inputShape->numOfVectors; i++) {
         for (int j = 0; j < 4; j++) {
             if (compareFloat(expected[i]->element[j], inputShape->points[i]->element[j], 0.000001)) {
                 for (int i = 0; i < 5; i++) {
@@ -515,7 +515,7 @@ int testYRotationHandlesNullElementOfMatrix() {
     yRotation();
 
     transformationMatrix[0] = temp;
-    for (int i = 0; i < inputShape->numOfPoints; i++) {
+    for (int i = 0; i < inputShape->numOfVectors; i++) {
         for (int j = 0; j < 4; j++) {
             if (compareFloat(expected[i]->element[j], inputShape->points[i]->element[j], 0.000001)) {
                 for (int i = 0; i < 5; i++) {
@@ -557,7 +557,7 @@ int testYRotationHandlesNullPoint() {
     yRotation();
 
     inputShape->points[1] = temp;
-    for (int i = 0; i < inputShape->numOfPoints; i++) {
+    for (int i = 0; i < inputShape->numOfVectors; i++) {
         for (int j = 0; j < 4; j++) {
             if (compareFloat(expected[i]->element[j], inputShape->points[i]->element[j], 0.000001)) {
                 printf("%d %d %f %f\n", i, j, expected[i]->element[j], inputShape->points[i]->element[j]);
@@ -598,7 +598,7 @@ int testYRotationHandlesNullPoints() {
 // ~~~~~~ Other Funcs ~~~~~~ //
 // ~~~~~~~~~~~~~~~~~~~~~~~~~ //
 void setup() {
-    inputShape->numOfPoints = 5;
+    inputShape->numOfVectors = 5;
     inputShape->rotation[1] = 0;
 
     for (int i = 0; i < 5; i++) {

--- a/ScalingInX/ScalingInX.c
+++ b/ScalingInX/ScalingInX.c
@@ -1,0 +1,24 @@
+#include "ScalingInX.h"
+
+void xScaling() {
+  //Rest transformation matrix before use
+  resetMatrix();
+  //set the first coordinate to x scale 
+  transformationMatrix[0][0] = getXScale();
+
+  //Use the transformation matrix and multiply the vectors 
+  struct point **currentVector;
+  float temp;
+  
+  //loop through the number of points
+  for (int k = 0; k < inputShape -> numOfVectors; k++) {
+    *currentVector = getPoint(k);
+    multiplyMatrix(*currentVector, transformationMatrix);
+
+    //set point at index k to new transformed point
+    setPoint(k, *currentVector);
+  }
+  
+
+  resetMatrix();
+}

--- a/ScalingInX/ScalingInX.h
+++ b/ScalingInX/ScalingInX.h
@@ -1,0 +1,8 @@
+#ifndef GROUP_3_H
+#define GROUP_3_H
+
+#include "../main.h"
+
+void xScaling();
+
+#endif

--- a/ScalingInX/ScalingInXTests.c
+++ b/ScalingInX/ScalingInXTests.c
@@ -1,0 +1,301 @@
+#include "ScalingInXTests.h"
+#include "ScalingInX.h"
+
+
+void runScalingInXTests(){
+    zeroTransformationTest();
+    noTransformationTest();
+    doubleTransformationTest();
+    isScaleChanged();
+    transformationTest();
+    bool err = emptyMatrixSet();
+    if (err == true){
+        fprintf(stderr, "ERROR: Matrix is empty\n");
+    }
+}
+
+
+//Testing Functions Below
+
+//Checks for valid index to prevent overflow
+//Expecting index to be withing range of the length of the shape
+//Fails if index is not within the correct bounds (0 - length)
+bool validIndex (int index) {
+  if (index >= 0 || index < inputShape->numOfVectors) {
+    return true;
+  }
+
+  printf("Error: Invalid index for ");
+  return false;
+}
+
+//Checks if the indices in the point Array are initialized
+//GLOBAL TEST FUNCTION (areVectorsSet - group 1)
+
+/*bool arevectorsInitialized(){
+  for (int i = 0; i < 4; i++){
+    if (arevectorsSet[i] == false){
+      return false;
+    }
+  }
+  return true;
+}*/
+
+// Function testing for null pointers
+// Expecting the pointer to be initialized with a value that is not NULL
+// Fails is the the pointer is equal to NULL
+bool isNull (void *pointer) {
+  if (pointer == NULL) {
+    fprintf(stderr, "ERROR: Pointer vectors to NULL.\n");
+    return true; // returns error value if null
+  }
+
+  return false;
+}
+
+// Function testing for get and set scale functions
+// Gets current scale value and modifies it to new Scale, setting it. 
+//If the old scale and the current scale (accessed with getXScale) are
+//equal, there is an error.
+bool isScaleChanged(){
+  float scale = getXScale();
+  float newScale = scale * -1.5;
+  setXScale(newScale);
+
+  //Testing equivalency with previous scale and current one
+  if (scale == getXScale()){
+    return false;
+  }
+  return true;
+}
+
+//Function tries to assign an empty matrix to the transformation matrix.
+//returns false
+bool emptyMatrixSet(){
+  float ** garbageMatrix;
+
+  //assigns memory to tmpMatrix but doesn't assign values
+  float ** tmpMatrix = malloc(sizeof(float *) * 4);
+  for (int i = 0; i < 4; i++) {
+    tmpMatrix[i] = malloc(sizeof(float) * 4);
+  }
+
+  //Gets the empty matrix
+  garbageMatrix = tmpMatrix;
+  //loop through matrix
+  for (int i = 0; i < 4; i++){
+    for (int j = 0; j < 4; j++){
+      //if the matrix is not made up of all zeros, there
+      //are garbage values
+      if (garbageMatrix[i][j] != 0){
+        //Matrix will not work
+        return false;
+      }
+    }
+  }
+  //Matrix will work
+  return false;
+}
+
+// Tests if all modified vectors have a 1 as their fourth element
+// Expecting all elements at index 3 for each point to have the value of 1
+// Fails if an element as index 3 does not equal 1
+bool ispointCorrect (float **vectors){
+  struct point *temppoint;
+  
+  //Loop through all the vectors and assign to a temppoint
+  for (int i = 0; i < inputShape -> numOfVectors; i++){
+    temppoint = getPoint(i);
+
+    //check if the fourth coordinate of temppoint is equal to 1.
+    if (temppoint -> element[3] != 1)
+      fprintf(stderr, "ERROR: vectors[%d][3] doesn't equal 1.\n", i);
+      return false;
+  }
+  return true;
+}
+
+// Function testing for proper transformation
+bool xAffected() {
+  //If scale = 1, transformation matrix will not change vectors
+  if(getXScale() == 1) {
+    return false;
+  }
+
+  return true;
+}
+
+
+// In the event after transformation, checks if y and z coordinates are changed and if the x coordinate is changed with proper scaling
+// Expecting transformation of x values with unchanged y and z values
+// Fails if the y or z values do not match the y or z values prior to the transformation 
+void transformationTest() {
+  int numOfPoints = 6;
+  struct point *points[numOfPoints];
+  //Creates vectors array struct as well as a double pointer float to hold the temporary vectors
+  float **tempvectors = malloc(sizeof(float *) * numOfPoints);
+
+  //gets the vectors from 
+  for (int i = 0; i < numOfPoints; i++) {
+    points[i] = getPoint(i); //vectors
+  }
+
+  //Assigns the vectors gotten from the shape structure to the tempvectors
+  for (int i = 0; i < inputShape->numOfVectors; i++) {
+    tempvectors[i] = malloc(sizeof(float) * 4);
+    for (int j = 0; j < 4; j++) {
+      tempvectors[i][j] = points[i] -> element[j];
+    }
+  }
+
+  //run function with vectors and matrix 
+  setXScale(3.5);
+  xScaling();
+
+  //update vectors after transformation
+  for (int i = 0; i < inputShape->numOfVectors; i++) {
+    points[i] = getPoint(i);
+  }
+
+  //Makes sure scaling is not 1
+  if (xAffected()) {
+    //loop through each point
+    for(int i = 0; i < inputShape->numOfVectors; i++){
+      //if x values match despite scaling affecting it, it did not transform
+      if(points[i] -> element[0] == tempvectors[i][0]){
+          fprintf(stderr, "'TransformationTest' function failed:\n\telement at %d,0 is incorrect\n", i);
+          return;
+      }
+      
+      //if y and z values do not match after transforming only the x coordinates, it did not transform correctly
+      for(int j = 1; j < 4; j++){
+        //y or z values do not match after transformation
+        if(points[i] -> element[j] != tempvectors[i][j]){
+          printf("'TransformationTest' function failed:\n\telement at %d,%d is incorrect\n", i,j);
+          return;
+        }
+      }
+    }
+  }
+
+  //Free all coordinates, vectors, and tempvectors
+  for (int i = 0; i < inputShape->numOfVectors; i++) {
+    free(tempvectors[i]);
+  }
+  free(tempvectors);
+  resetMatrix();
+}
+
+// Testing a transformation with an x transformation factor of 0 for correct values
+// Expecting the transformed vectors to have a x value (index of [0]) of 0 after the transformation
+// Fails if the transformed vectors do not have x values (index of [0]) that are 0   
+void zeroTransformationTest () {
+  struct point *newPoint[4];
+
+  //Assign a random values to the 4 vectors
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      //puts random numbers in vectors 
+      newPoint[i] -> element[j] = (float) (rand() % 100);
+    }
+
+    //Set the matrix and the vectors, assigning the last coordinate to one
+    newPoint[i] -> element[3] = 1;
+    setPoint (i, newPoint[i]);
+  }
+
+  setXScale(0);
+  xScaling();
+
+  for (int i = 0; i < inputShape->numOfVectors; i++) {
+    newPoint[i] = getPoint(i);
+    //Ensure that modified vectors x-value is equal to 0
+    if (newPoint[i] -> element[0] != 0 ) {
+      fprintf(stderr, "ERROR: Zero multiplication test failed: multiplying x value of point %d by 0 resulted in a non zero value\n", i);
+      return;
+    }
+  }
+
+  resetMatrix();
+}
+
+// Testing a transformation with an x transformation factor of 1 for correct values
+// Expecting the transformed vectors to have the same x value (index of [0]) after the transformation
+// Fails if the transformed vectors do not have x values (index of [0]) that are the same as the original vectors  
+void noTransformationTest () {
+  float **matrix = malloc(sizeof (float *) * 4);
+  struct point *newPoint[4], *currentpoint;
+  //Assign a 0 value to the number of vectors
+  //initializeLength();
+
+  //loop through the matrix
+  for (int i = 0; i < 4; i++) {
+    matrix[i] = malloc(sizeof(float) * 4);
+
+    for (int j = 0; j < 4; j++) {
+      //puts random numbers in vectors
+      newPoint[i] -> element[j] = (float) (rand() % 100); 
+    }
+    //Set vectors (ensuring 1 is last coordinate)
+    newPoint[i] -> element[3] = 1;
+    setPoint (i, newPoint[i]);
+  }
+  
+  setXScale(1);
+  xScaling();
+
+  //Assigns transformed vectors to currentpoint
+  for (int i = 0; i < inputShape->numOfVectors; i++) {
+    currentpoint = getPoint(i);
+
+    //if the vectors before and transformations are not equal, there is an error
+    if (newPoint[i] -> element[0] != currentpoint -> element[0]) {
+      fprintf(stderr, "ERROR: No transformation test failed: X value of point %d multiplied by 1 gave a different result: %f.\n", i, currentpoint -> element[0]);
+      return;
+    }
+  }
+
+  resetMatrix();
+}
+
+// Testing a transformation with an x transformation factor of 2 for correct values
+// Expecting the transformed vectors to have a double x value (index of [0]) after the transformation
+// Fails if the transformed vectors do not have x values (index of [0]) that are double the original vectors  
+void doubleTransformationTest () {
+  float **matrix = malloc(sizeof (float *) * 4);
+  struct point *newPoint[4], *currentpoint;
+  //Assign a 0 value to the number of vectors
+  //initializeLength();
+  //loop through the matrix
+  for (int i = 0; i < 4; i++) {
+    matrix[i] = malloc(sizeof(float) * 4);
+
+    for (int j = 0; j < 4; j++) {
+      //puts random numbers in vectors
+      newPoint[i] -> element[j] = (float) (rand() % 100); 
+    }
+
+    // Sets point and matrix
+    // setMatrix(matrix);
+    newPoint[i] -> element[3] = 1;
+    setPoint (i, newPoint[i]);
+  }
+  
+  //Transforms vectors by a factor of 2
+  setXScale(2);
+  xScaling();
+
+  //Assigns transformed vectors to currentpoint
+  for (int i = 0; i < inputShape->numOfVectors; i++) {
+    currentpoint = getPoint(i);
+
+    //if the modified point's x coordinate's are not halved, there is an error
+    if (newPoint[i] -> element[0] != currentpoint -> element[0] * 0.5) {
+      fprintf(stderr, "ERROR: Double transformation test failed: X value (%f) of point %d multiplied by 2 gave a wrong result: %f.\n", newPoint[i] -> element[0], i, currentpoint -> element[0]);
+      return;
+    }
+  }
+
+  resetMatrix();
+}
+

--- a/ScalingInX/ScalingInXTests.h
+++ b/ScalingInX/ScalingInXTests.h
@@ -1,0 +1,16 @@
+#ifndef GROUP_3_TESTS_H
+#define GROUP_3_TESTS_H
+
+#include "../main.h"
+#include <stdbool.h>
+
+void runScalingInXTests();
+void zeroTransformationTest();
+void noTransformationTest();
+void doubleTransformationTest();
+bool isScaleChanged();
+bool emptyMatrixSet();
+void transformationTest();
+
+#endif
+

--- a/groupIncludes.h
+++ b/groupIncludes.h
@@ -11,7 +11,7 @@
 #include "Group16/Group16.h"
 #include "Group17/Group17.h"
 #include "Group2/Group2.h"
-#include "Group3/Group3.h"
+#include "ScalingInX/ScalingInX.h"
 #include "Group4/Group4.h"
 #include "Group5/Group5.h"
 #include "Group6/Group6.h"

--- a/groupTestIncludes.h
+++ b/groupTestIncludes.h
@@ -2,5 +2,6 @@
 #define GROUP_TEST_INCLUDES_H
 
 #include "RotationInY/RotationInYTests.h"
+#include "ScalingInX/ScalingInXTests.h"
 
 #endif

--- a/main.c
+++ b/main.c
@@ -87,7 +87,7 @@ float getGloalScale() {
 }
 
 float getXScale() {
-    return 0;
+    return inputShape -> scaling[0];
 }
 
 float getYScale() {
@@ -153,6 +153,7 @@ void setGlobalScale(float newGlobalScale) {
 }
 
 void setXScale(float newXScale) {
+  inputShape -> scaling[0] = newXScale;
 }
 
 void setYScale(float newYScale) {
@@ -211,6 +212,20 @@ void multiplyMatrix(struct point* currPoint, float matrix[4][4]) {
     }
 }
 
+//Reset transformation matrix to the identity matrix
+void resetMatrix(){
+  for (int i = 0; i < 4; i++){
+      for (int j = 0; j < 4; j++){
+          if (i == j){
+              transformationMatrix[i][j] = 1;
+          }
+          else{
+              transformationMatrix[i][j] = 0;
+          }
+      }
+  }
+}
+
 void runAllTests() {
     int i;
     inputShape = malloc(sizeof(struct shape));
@@ -233,6 +248,7 @@ void runAllTests() {
     }
 
     // TESTS GO HERE
+    runScalingInXTests();  // Group 3 tests
     runGroup7Tests();  // Group 7 tests
 
     // free

--- a/main.h
+++ b/main.h
@@ -23,7 +23,8 @@ struct shape* inputShape;
 char* fileName;
 
 //~~~~~~ Global Functions ~~~~~~//
-void multiplyMatrix(struct point* currPoint, float[4][4] matrix);
+void multiplyMatrix(struct point* currPoint, float matrix[4][4]);
+void resetMatrix();
 
 //~~~~~~ Getters ~~~~~~//
 struct point* getPoint(int index);

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 CC = clang
-CFLGS = -std=c99 -Wall -pedantic
+CFLAGS = -std=c99 -Wall -pedantic
 EXECS = main
-O_FILES = Group1/Group1.o Group2/Group2.o Group3/Group3.o Group4/Group4.o Group5/Group5.o Group6/Group6.o RotationInY/RotationInY.o Group8/Group8.o Group9/Group9.o Group10/Group10.o Group11/Group11.o Group12/Group12.o Group13/Group13.o Group14/Group14.o Group15/Group15.o Group16/Group16.o Group17/Group17.o Group1/Group1Tests.o Group2/Group2Tests.o Group3/Group3Tests.o Group4/Group4Tests.o Group5/Group5Tests.o Group6/Group6Tests.o RotationInY/RotationInYTests.o Group8/Group8Tests.o Group9/Group9Tests.o Group10/Group10Tests.o Group11/Group11Tests.o Group12/Group12Tests.o Group13/Group13Tests.o Group14/Group14Tests.o Group15/Group15Tests.o Group16/Group16Tests.o Group17/Group17Tests.o
+O_FILES = Group1/Group1.o Group2/Group2.o ScalingInX/ScalingInX.o Group4/Group4.o Group5/Group5.o Group6/Group6.o RotationInY/RotationInY.o Group8/Group8.o Group9/Group9.o Group10/Group10.o Group11/Group11.o Group12/Group12.o Group13/Group13.o Group14/Group14.o Group15/Group15.o Group16/Group16.o Group17/Group17.o Group1/Group1Tests.o Group2/Group2Tests.o ScalingInX/ScalingInXTests.o Group4/Group4Tests.o Group5/Group5Tests.o Group6/Group6Tests.o RotationInY/RotationInYTests.o Group8/Group8Tests.o Group9/Group9Tests.o Group10/Group10Tests.o Group11/Group11Tests.o Group12/Group12Tests.o Group13/Group13Tests.o Group14/Group14Tests.o Group15/Group15Tests.o Group16/Group16Tests.o Group17/Group17Tests.o
 H_FILES = main.h groupIncludes.h groupTestIncludes.h
 
 all: $(EXECS)
@@ -19,108 +19,108 @@ main: main.o $(O_FILES) $(H_FILES)
 	$(CC) $(CFLAGS) main.o $(O_FILES) -o main -lm
 	
 main.o: main.c $(H_FILES)
-	$(CC) $(CFLASG) -c main.c -o main.o
+	$(CC) $(CFLAGS) -c main.c -o main.o
 
 #Group O Files
 Group1/Group1.o: Group1/Group1.c Group1/Group1.h main.h
-	$(CC) $(CFLGAS) -c Group1/Group1.c -o Group1/Group1.o
+	$(CC) $(CFLAGS) -c Group1/Group1.c -o Group1/Group1.o
 
 Group2/Group2.o: Group2/Group2.c Group2/Group2.h main.h
-	$(CC) $(CFLGAS) -c Group2/Group2.c -o Group2/Group2.o
+	$(CC) $(CFLAGS) -c Group2/Group2.c -o Group2/Group2.o
 
-Group3/Group3.o: Group3/Group3.c Group3/Group3.h main.h
-	$(CC) $(CFLGAS) -c Group3/Group3.c -o Group3/Group3.o
+ScalingInX/ScalingInX.o: ScalingInX/ScalingInX.c ScalingInX/ScalingInX.h main.h
+	$(CC) $(CFLAGS) -c ScalingInX/ScalingInX.c -o ScalingInX/ScalingInX.o
 
 Group4/Group4.o: Group4/Group4.c Group4/Group4.h main.h
-	$(CC) $(CFLGAS) -c Group4/Group4.c -o Group4/Group4.o
+	$(CC) $(CFLAGS) -c Group4/Group4.c -o Group4/Group4.o
 
 Group5/Group5.o: Group5/Group5.c Group5/Group5.h main.h
-	$(CC) $(CFLGAS) -c Group5/Group5.c -o Group5/Group5.o
+	$(CC) $(CFLAGS) -c Group5/Group5.c -o Group5/Group5.o
 
 Group6/Group6.o: Group6/Group6.c Group6/Group6.h main.h
-	$(CC) $(CFLGAS) -c Group6/Group6.c -o Group6/Group6.o
+	$(CC) $(CFLAGS) -c Group6/Group6.c -o Group6/Group6.o
 
 RotationInY/RotationInY.o: RotationInY/RotationInY.c RotationInY/RotationInY.h main.h
-	$(CC) $(CFLGAS) -c RotationInY/RotationInY.c -o RotationInY/RotationInY.o
+	$(CC) $(CFLAGS) -c RotationInY/RotationInY.c -o RotationInY/RotationInY.o
 
 Group8/Group8.o: Group8/Group8.c Group8/Group8.h main.h
-	$(CC) $(CFLGAS) -c Group8/Group8.c -o Group8/Group8.o
+	$(CC) $(CFLAGS) -c Group8/Group8.c -o Group8/Group8.o
 
 Group9/Group9.o: Group9/Group9.c Group9/Group9.h main.h
-	$(CC) $(CFLGAS) -c Group9/Group9.c -o Group9/Group9.o
+	$(CC) $(CFLAGS) -c Group9/Group9.c -o Group9/Group9.o
 
 Group10/Group10.o: Group10/Group10.c Group10/Group10.h main.h
-	$(CC) $(CFLGAS) -c Group10/Group10.c -o Group10/Group10.o
+	$(CC) $(CFLAGS) -c Group10/Group10.c -o Group10/Group10.o
 
 Group11/Group11.o: Group11/Group11.c Group11/Group11.h main.h
-	$(CC) $(CFLGAS) -c Group11/Group11.c -o Group11/Group11.o
+	$(CC) $(CFLAGS) -c Group11/Group11.c -o Group11/Group11.o
 
 Group12/Group12.o: Group12/Group12.c Group12/Group12.h main.h
-	$(CC) $(CFLGAS) -c Group12/Group12.c -o Group12/Group12.o
+	$(CC) $(CFLAGS) -c Group12/Group12.c -o Group12/Group12.o
 
 Group13/Group13.o: Group13/Group13.c Group13/Group13.h main.h
-	$(CC) $(CFLGAS) -c Group13/Group13.c -o Group13/Group13.o
+	$(CC) $(CFLAGS) -c Group13/Group13.c -o Group13/Group13.o
 
 Group14/Group14.o: Group14/Group14.c Group14/Group14.h main.h
-	$(CC) $(CFLGAS) -c Group14/Group14.c -o Group14/Group14.o
+	$(CC) $(CFLAGS) -c Group14/Group14.c -o Group14/Group14.o
 
 Group15/Group15.o: Group15/Group15.c Group15/Group15.h main.h
-	$(CC) $(CFLGAS) -c Group15/Group15.c -o Group15/Group15.o
+	$(CC) $(CFLAGS) -c Group15/Group15.c -o Group15/Group15.o
 
 Group16/Group16.o: Group16/Group16.c Group16/Group16.h main.h
-	$(CC) $(CFLGAS) -c Group16/Group16.c -o Group16/Group16.o
+	$(CC) $(CFLAGS) -c Group16/Group16.c -o Group16/Group16.o
 
 Group17/Group17.o: Group17/Group17.c Group17/Group17.h main.h
-	$(CC) $(CFLGAS) -c Group17/Group17.c -o Group17/Group17.o
+	$(CC) $(CFLAGS) -c Group17/Group17.c -o Group17/Group17.o
 
 #Group Test O Files
 Group1/Group1Tests.o: Group1/Group1Tests.c Group1/Group1Tests.h main.h
-	$(CC) $(CFLGAS) -c Group1/Group1Tests.c -o Group1/Group1Tests.o
+	$(CC) $(CFLAGS) -c Group1/Group1Tests.c -o Group1/Group1Tests.o
 
 Group2/Group2Tests.o: Group2/Group2Tests.c Group2/Group2Tests.h main.h
-	$(CC) $(CFLGAS) -c Group2/Group2Tests.c -o Group2/Group2Tests.o
+	$(CC) $(CFLAGS) -c Group2/Group2Tests.c -o Group2/Group2Tests.o
 
-Group3/Group3Tests.o: Group3/Group3Tests.c Group3/Group3Tests.h main.h
-	$(CC) $(CFLGAS) -c Group3/Group3Tests.c -o Group3/Group3Tests.o
+ScalingInX/ScalingInXTests.o: ScalingInX/ScalingInXTests.c ScalingInX/ScalingInXTests.h main.h
+	$(CC) $(CFLAGS) -c ScalingInX/ScalingInXTests.c -o ScalingInX/ScalingInXTests.o
 
 Group4/Group4Tests.o: Group4/Group4Tests.c Group4/Group4Tests.h main.h
-	$(CC) $(CFLGAS) -c Group4/Group4Tests.c -o Group4/Group4Tests.o
+	$(CC) $(CFLAGS) -c Group4/Group4Tests.c -o Group4/Group4Tests.o
 
-Group5/Group5Tests.o: Group5/Group5Tests.c Group5/Group5Tests.h main.h
-	$(CC) $(CFLGAS) -c Group5/Group5Tests.c -o Group5/Group5Tests.o
+Group5/Group5TCFLAGSests.o: Group5/Group5Tests.c Group5/Group5Tests.h main.h
+	$(CC) $(CFLAGS) -c Group5/Group5Tests.c -o Group5/Group5Tests.o
 
 Group6/Group6Tests.o: Group6/Group6Tests.c Group6/Group6Tests.h main.h
-	$(CC) $(CFLGAS) -c Group6/Group6Tests.c -o Group6/Group6Tests.o
+	$(CC) $(CFLAGS) -c Group6/Group6Tests.c -o Group6/Group6Tests.o
 
 RotationInY/RotationInYTests.o: RotationInY/RotationInYTests.c RotationInY/RotationInYTests.h main.h
-	$(CC) $(CFLGAS) -c RotationInY/RotationInYTests.c -o RotationInY/RotationInYTests.o
+	$(CC) $(CFLAGS) -c RotationInY/RotationInYTests.c -o RotationInY/RotationInYTests.o
 
 Group8/Group8Tests.o: Group8/Group8Tests.c Group8/Group8Tests.h main.h
-	$(CC) $(CFLGAS) -c Group8/Group8Tests.c -o Group8/Group8Tests.o
+	$(CC) $(CFLAGS) -c Group8/Group8Tests.c -o Group8/Group8Tests.o
 
 Group9/Group9Tests.o: Group9/Group9Tests.c Group9/Group9Tests.h main.h
-	$(CC) $(CFLGAS) -c Group9/Group9Tests.c -o Group9/Group9Tests.o
+	$(CC) $(CFLAGS) -c Group9/Group9Tests.c -o Group9/Group9Tests.o
 
 Group10/Group10Tests.o: Group10/Group10Tests.c Group10/Group10Tests.h main.h
-	$(CC) $(CFLGAS) -c Group10/Group10Tests.c -o Group10/Group10Tests.o
+	$(CC) $(CFLAGS) -c Group10/Group10Tests.c -o Group10/Group10Tests.o
 
 Group11/Group11Tests.o: Group11/Group11Tests.c Group11/Group11Tests.h main.h
-	$(CC) $(CFLGAS) -c Group11/Group11Tests.c -o Group11/Group11Tests.o
+	$(CC) $(CFLAGS) -c Group11/Group11Tests.c -o Group11/Group11Tests.o
 
 Group12/Group12Tests.o: Group12/Group12Tests.c Group12/Group12Tests.h main.h
-	$(CC) $(CFLGAS) -c Group12/Group12Tests.c -o Group12/Group12Tests.o
+	$(CC) $(CFLAGS) -c Group12/Group12Tests.c -o Group12/Group12Tests.o
 
 Group13/Group13Tests.o: Group13/Group13Tests.c Group13/Group13Tests.h main.h
-	$(CC) $(CFLGAS) -c Group13/Group13Tests.c -o Group13/Group13Tests.o
+	$(CC) $(CFLAGS) -c Group13/Group13Tests.c -o Group13/Group13Tests.o
 
 Group14/Group14Tests.o: Group14/Group14Tests.c Group14/Group14Tests.h main.h
-	$(CC) $(CFLGAS) -c Group14/Group14Tests.c -o Group14/Group14Tests.o
+	$(CC) $(CFLAGS) -c Group14/Group14Tests.c -o Group14/Group14Tests.o
 
 Group15/Group15Tests.o: Group15/Group15Tests.c Group15/Group15Tests.h main.h
-	$(CC) $(CFLGAS) -c Group15/Group15Tests.c -o Group15/Group15Tests.o
+	$(CC) $(CFLAGS) -c Group15/Group15Tests.c -o Group15/Group15Tests.o
 
 Group16/Group16Tests.o: Group16/Group16Tests.c Group16/Group16Tests.h main.h
-	$(CC) $(CFLGAS) -c Group16/Group16Tests.c -o Group16/Group16Tests.o
+	$(CC) $(CFLAGS) -c Group16/Group16Tests.c -o Group16/Group16Tests.o
 
 Group17/Group17Tests.o: Group17/Group17Tests.c Group17/Group17Tests.h main.h
-	$(CC) $(CFLGAS) -c Group17/Group17Tests.c -o Group17/Group17Tests.o
+	$(CC) $(CFLAGS) -c Group17/Group17Tests.c -o Group17/Group17Tests.o


### PR DESCRIPTION
Fixed a typo in RotationInYTests.c that was causing compilation errors: all instances of (inputShape -> numOfPoints) were changed to (inputShape -> numOfVectors).
Added ScalingInX implementation and tests.
Updated header files.
Updated makefile: fixed typo in CFLAGS and added ScalingInX files.

 
