### PR TITLE
Statically allocated filenames

### DIFF
--- a/main.c
+++ b/main.c
@@ -8,15 +8,9 @@ int main(int argc, char** argv) {
     if (argc == 2 && strcmp(argv[1], "-t") == 0) {
         runAllTests();
     } else if (argc == 4) {
-        inputFileName = malloc(sizeof(char) * BUFSIZ);
-        strncpy(inputFileName, argv[1], BUFSIZ);
-
-        transformationFileName = malloc(sizeof(char) * BUFSIZ); 
-        strncpy(transformationFileName, argv[2], BUFSIZ);
-        
-        outputFileName = malloc(sizeof(char) * BUFSIZ);
-
-        strncpy(outputFileName, argv[3], BUFSIZ);
+        char * inputFileName = argv[1];
+        char * transformationFileName = argv[2]; 
+        char * outputFileName = argv[3];
         
         //~~~~~ Reading file input ~~~~~//
         readInput(inputFileName, transformationFileName);
@@ -90,9 +84,6 @@ int main(int argc, char** argv) {
 
         // free shape
         free(inputShape);
-        free(transformationFileName);
-        free(inputFileName);
-        free(outputFileName);
     }
     else {
         fprintf(stderr, "Format %s <input file> <transformation file> <output file>\n", argv[0]);

--- a/main.h
+++ b/main.h
@@ -22,9 +22,6 @@ struct shape {
 
 float transformationMatrix[4][4];
 struct shape* inputShape;
-char* inputFileName;
-char* transformationFileName;
-char* outputFileName;
 
 //~~~~~~ Global Functions ~~~~~~//
 void multiplyMatrix(struct point* currPoint, float matrix[4][4]);


### PR DESCRIPTION
Changes:
- filenames are directly referenced instead of being copied into the heap
- filenames are local instead of global

Rationale:
- Since we're not reading user input from stdin there is no need to heap allocate memory and we 
  can directly reference the command line args.
- Changed from global to local since they were being passed to the functions anyways and reduces
  number of variables in the global scope.

Pros:
- We don't need to worry about handling the memory or malloc failing and the code is cleaner overall.

Cons:
- 🤷🏾‍♂️ 