### PR TITLE
Consistency changes for group 4 + final executable name

### DIFF
--- a/ScalingInY/ScalingInY.c
+++ b/ScalingInY/ScalingInY.c
@@ -16,7 +16,7 @@
  * Since only y is modified by a variable value, yScaling transforms the matrix by focusing on
  * only the y value of the point
  */
-int yScaling() {
+void yScaling() {
     struct point *curPoint;      // Holds current point
     float yScale = getYScale();  // Y scale used to modify points
 
@@ -24,15 +24,8 @@ int yScaling() {
     // multiplying it by the yScale value.
     for (int curIndex = 0; curIndex < inputShape->numOfPoints; curIndex++) {
         curPoint = getPoint(curIndex);
-
-        if (curPoint == NULL) {
-            // point at this index is not initialised
-            // fprintf(stderr, "ERROR: Could not perform yScaling function as point at index %d was NULL.\n", curIndex);
-            return 0;
-        }
-
         curPoint->element[1] *= yScale;
+        // Set point back to transformed value
         setPoint(curIndex, curPoint);
     }
-    return 1;
 }

--- a/ScalingInY/ScalingInY.c
+++ b/ScalingInY/ScalingInY.c
@@ -18,13 +18,16 @@
  */
 void yScaling() {
     struct point *curPoint;      // Holds current point
-    float yScale = getYScale();  // Y scale used to modify points
+    
+    // Setup transformation matrix
+    resetMatrix();
+    transformationMatrix[1][1] = getYScale();  // Y scale used to modify points
 
     // Iterate through each point in the point array and update the y value by
     // multiplying it by the yScale value.
     for (int curIndex = 0; curIndex < inputShape->numOfPoints; curIndex++) {
         curPoint = getPoint(curIndex);
-        curPoint->element[1] *= yScale;
+        multiplyMatrix(curPoint, transformationMatrix);
         // Set point back to transformed value
         setPoint(curIndex, curPoint);
     }

--- a/ScalingInY/ScalingInY.c
+++ b/ScalingInY/ScalingInY.c
@@ -18,10 +18,8 @@
  */
 void yScaling() {
     struct point *curPoint;      // Holds current point
-    
-    // Setup transformation matrix
-    resetMatrix();
-    transformationMatrix[1][1] = getYScale();  // Y scale used to modify points
+    // Reset transformation matrix
+    setupTransformationMatrixForYScaling();
 
     // Iterate through each point in the point array and update the y value by
     // multiplying it by the yScale value.
@@ -31,4 +29,11 @@ void yScaling() {
         // Set point back to transformed value
         setPoint(curIndex, curPoint);
     }
+}
+
+void setupTransformationMatrixForYScaling() {
+    // Reset transformation matrix
+    resetMatrix();
+    // Set to Y scale used to modify points
+    transformationMatrix[1][1] = getYScale(); 
 }

--- a/ScalingInY/ScalingInY.h
+++ b/ScalingInY/ScalingInY.h
@@ -3,6 +3,6 @@
 
 #include "../main.h"
 
-int yScaling();
+void yScaling();
 
 #endif

--- a/ScalingInY/ScalingInY.h
+++ b/ScalingInY/ScalingInY.h
@@ -4,5 +4,6 @@
 #include "../main.h"
 
 void yScaling();
+void setupTransformationMatrixForYScaling();
 
 #endif

--- a/ScalingInY/ScalingInYTests.c
+++ b/ScalingInY/ScalingInYTests.c
@@ -7,11 +7,7 @@
 /* This function initializes the Y values for the first 5 points in the point
  * array found in the 'points' field in inputShape. Values used (in the order
  * of array index) are 0, 1, -1, 100, -100 */
-void initialisePoints() {
-    //inputShape->points = malloc(sizeof(struct point *) * 5);
-    //struct point *newPoint = malloc(sizeof(struct point));
-    // x, z, global all = 1
-    //inputShape->numOfPoints = 5;
+void populatePoints() {
     float yValues[5] = {0, 1, -1, 100, -100};
     for (int i = 0; i < inputShape->numOfPoints; i++) {
         struct point * newPoint = getPoint(i);
@@ -21,7 +17,6 @@ void initialisePoints() {
         newPoint->element[1] = yValues[i];
         setPoint(i, newPoint);
     }
-    //free(newPoint);
 }
 
 void testExpectedValues(char *testName, float *expectedValues) {
@@ -46,40 +41,16 @@ void testExpectedValues(char *testName, float *expectedValues) {
 
 //- Test functions
 
-/* This test will attempt to run the yScaling function with an initialized scale
- * value but no initialized points. It is expected that the function will catch
- * the uninitialized value and return 0, indicating that the scale operation
- * could not be performed. */
-void uninitialisedYPointTest() {
-    float yScaleValue = 42.0;  // Y-scale value chosen for the test
-    int expectedResult = 0;    // The expected result of the yScaling function
-    struct point ** tempPoints = inputShape->points;
-    inputShape->points = NULL;
-
-    // Setup for test
-    setYScale(yScaleValue);
-    int result = yScaling();
-
-    // Print message if the test fails
-    if (result != expectedResult) {
-        printf("Failed uninitialisedYPointTest\n");
-        printf("- Expected: %5d\n", expectedResult);
-        printf("-   Actual: %5d\n\n", result);
-    }
-
-    inputShape->points = tempPoints;
-}
-
 /* This test will confirm that the yScaling function correctly computes and sets
  * the Y value for points when given a negative Y scale value. The expected
- * results for each of the Y point values set in the initialisePoints function
+ * results for each of the Y point values set in the populatePoints function
  * are 0, -22.0, 22.0, -2200.0, and 2200.0 respectively. */
 void testNegativeScale() {
     float expectedValues[5] = {0, -22.0, 22.0, -2200.0, 2200.0};
     float yScaleValue = -22.0;
 
     // Setup for test
-    initialisePoints();
+    populatePoints();
     setYScale(yScaleValue);
     yScaling();
 
@@ -89,13 +60,13 @@ void testNegativeScale() {
 
 /* This test will confirm that the yScaling function correctly computes and sets
  * the Y value for points when given a Y scale value of 0. The expected results
- * for all of the Y point values set in the initialisePoints function are 0. */
+ * for all of the Y point values set in the populatePoints function are 0. */
 void testZeroScale() {
     float expectedValues[5] = {0, 0, 0, 0, 0};
     float yScaleValue = 0.0;
 
     // Setup for test
-    initialisePoints();
+    populatePoints();
     setYScale(yScaleValue);
     yScaling();
 
@@ -105,14 +76,14 @@ void testZeroScale() {
 
 /* This test will confirm that the yScaling function correctly computes and sets
  * the Y value for points when given a positive Y scale value. The expected
- * results for each of the Y point values set in the initialisePoints function
+ * results for each of the Y point values set in the populatePoints function
  * are 0, 5, -5, 500, and -500 respectively. */
 void testPositiveScale() {
     float expectedValues[5] = {0, 5, -5, 500, -500};
     float yScaleValue = 5.0;
 
     // Setup for test
-    initialisePoints();
+    populatePoints();
     setYScale(yScaleValue);
     yScaling();
 
@@ -122,14 +93,14 @@ void testPositiveScale() {
 
 /* This test will confirm that the yScaling function correctly computes and sets
  * the Y value for points when given a fractional Y scale value. The expected
- * results for each of the Y point values set in the initialisePoints function
+ * results for each of the Y point values set in the populatePoints function
  * are 0, 0.5, -0.5, 50, and -50 respectively. */
 void testFractionScale() {
     float expectedValues[5] = {0, 0.5, -0.5, 50, -50};
     float yScaleValue = 0.5;
 
     // Setup for test
-    initialisePoints();
+    populatePoints();
     setYScale(yScaleValue);
     yScaling();
 
@@ -138,7 +109,6 @@ void testFractionScale() {
 }
 
 void runScalingInYTests() {   
-    uninitialisedYPointTest();
     testNegativeScale();
     testZeroScale();
     testPositiveScale();

--- a/ScalingInY/ScalingInYTests.h
+++ b/ScalingInY/ScalingInYTests.h
@@ -3,8 +3,6 @@
 
 #include "../main.h"
 
-void initialisePoints();
-void uninitialisedYPointTest();
 void testNegativeScale();
 void testZeroScale();
 void testPositiveScale();

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC = clang
 CFLAGS = -std=c99 -Wall -pedantic
-EXECS = main
+EXECS = final
 O_FILES = ReadInput/ReadInput.o GlobalScaling/GlobalScaling.o ScalingInX/ScalingInX.o ScalingInY/ScalingInY.o ScalingInZ/ScalingInZ.o RotationInX/RotationInX.o RotationInY/RotationInY.o RotationInZ/RotationInZ.o XYZTranslation/XYZTranslation.o XPlaneReflection/XPlaneReflection.o YPlaneReflection/YPlaneReflection.o ZPlaneReflection/ZPlaneReflection.o ShearInX/ShearInX.o ShearInY/ShearInY.o ShearInZ/ShearInZ.o xyzOrthographicProjection/xyzOrthographicProjection.o OutputResults/OutputResults.o ReadInput/ReadInputTests.o GlobalScaling/GlobalScalingTests.o ScalingInX/ScalingInXTests.o ScalingInY/ScalingInYTests.o ScalingInZ/ScalingInZTests.o RotationInX/RotationInXTests.o RotationInY/RotationInYTests.o RotationInZ/RotationInZTests.o XYZTranslation/XYZTranslationTests.o XPlaneReflection/XPlaneReflectionTests.o YPlaneReflection/YPlaneReflectionTests.o ZPlaneReflection/ZPlaneReflectionTests.o ShearInX/ShearInXTests.o ShearInY/ShearInYTests.o ShearInZ/ShearInZTests.o xyzOrthographicProjection/xyzOrthographicProjectionTests.o OutputResults/OutputResultsTests.o
 H_FILES = main.h groupIncludes.h groupTestIncludes.h
 
@@ -15,8 +15,8 @@ clean:
 %.o: %.c $(H_FILES)
 	$(CC) -c $(CFLAGS) $< -o $@
 
-main: main.o $(O_FILES) $(H_FILES)
-	$(CC) $(CFLAGS) main.o $(O_FILES) -o main -lm
+final: main.o $(O_FILES) $(H_FILES)
+	$(CC) $(CFLAGS) main.o $(O_FILES) -o final -lm
 	
 main.o: main.c $(H_FILES)
 	$(CC) $(CFLAGS) -c main.c -o main.o


### PR DESCRIPTION
Group 4-specific changes:
- Change yScaling() to a void (no errors are surfaced anymore)
- Stop erroring if points are NULL within yScaling, as no other group does + remove our test for this
- Use transformation matrix for scaling, with separate function for setting that matrix up

Other:
- Rename the final executable file to 'final', as requested by the professor